### PR TITLE
chore: release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/vi17250/git-branch/releases/tag/v0.0.1) - 2025-09-25
+
+### Added
+
+- 🎸 display origin
+- 🎸 display commit hash and time of HEAD
+- 🎸 display HEAD branch
+- 🎸 display last update in seconds
+- 🎸 display commit hash
+- 🎸 Commit is a struct included in Branch
+- 🎸 delete branches 🔥
+- 🎸 multiple selection for branches to delete
+- 🎸 add last update to Branch struct
+- 🎸 set head branch
+- 🎸 find refs directory and create branches
+- 🎸 find .git directory
+- 🎸 initial_commit
+
+### Fixed
+
+- 🐛 remove useless import
+- 🐛 display HEAD even if it's origin
+- 🐛 displays the human-readable modification time
+- 🐛 The selection cannot go beyond the list of branches
+- 🐛 dialog interface highlight branch
+- 🐛 returns an error if no git repository was found
+- 🐛 display message when no branches are found
+- 🐛 returns all branches without HEAD
+- 🐛 Exit process
+- 🐛 add logs_dir in Branch struct
+
+### Other
+
+- 🎡 release with release-plz
+- 🤖 cliff configuration for CHANGELOG generation
+- 🎡 build and test
+- ✏️ todo
+- ✏️ who is it useful for?
+- ✏️ informations about git-branch
+- 💡 errors handling
+- Update version in Cargo.toml
+- 💡 HEAD domain
+- 🤖 rename crate
+- ✏️ project is not yet ready
+- 💡 the folder structure is organized by subject area
+- 💍 branches filter
+- ✏️ idea from the sorcerer


### PR DESCRIPTION



## 🤖 New release

* `git-branch`: 0.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.1](https://github.com/vi17250/git-branch/releases/tag/v0.0.1) - 2025-09-25

### Added

- 🎸 display origin
- 🎸 display commit hash and time of HEAD
- 🎸 display HEAD branch
- 🎸 display last update in seconds
- 🎸 display commit hash
- 🎸 Commit is a struct included in Branch
- 🎸 delete branches 🔥
- 🎸 multiple selection for branches to delete
- 🎸 add last update to Branch struct
- 🎸 set head branch
- 🎸 find refs directory and create branches
- 🎸 find .git directory
- 🎸 initial_commit

### Fixed

- 🐛 remove useless import
- 🐛 display HEAD even if it's origin
- 🐛 displays the human-readable modification time
- 🐛 The selection cannot go beyond the list of branches
- 🐛 dialog interface highlight branch
- 🐛 returns an error if no git repository was found
- 🐛 display message when no branches are found
- 🐛 returns all branches without HEAD
- 🐛 Exit process
- 🐛 add logs_dir in Branch struct

### Other

- 🎡 release with release-plz
- 🤖 cliff configuration for CHANGELOG generation
- 🎡 build and test
- ✏️ todo
- ✏️ who is it useful for?
- ✏️ informations about git-branch
- 💡 errors handling
- Update version in Cargo.toml
- 💡 HEAD domain
- 🤖 rename crate
- ✏️ project is not yet ready
- 💡 the folder structure is organized by subject area
- 💍 branches filter
- ✏️ idea from the sorcerer
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).