### PR TITLE
fix: 🐛 display last commit update time

### DIFF
--- a/src/branches/def.rs
+++ b/src/branches/def.rs
@@ -55,7 +55,7 @@ impl Display for Branch {
             self.name
                 .to_str()
                 .expect("Failed to parse OsString to String")
-                .truncate_to_boundary(12),
+                .truncate_to_boundary(10),
         )
         .bold();
 
@@ -63,25 +63,24 @@ impl Display for Branch {
             name = name.red();
         };
 
-        let diff = self
-            .last_update
-            .elapsed()
-            .expect("Failed tu parse last update")
-            .as_secs();
-
-        let last_update = parse_time(&diff);
-
-        let commit = match &self.commit {
-            Some(commit) => format!("{commit}"),
-            None => String::new(),
+        let (last_update, message) = match &self.commit {
+            Some(commit) => {
+                let diff = commit
+                    .get_timestamp()
+                    .elapsed()
+                    .expect("Failes to parse last commit update")
+                    .as_secs();
+                (parse_time(&diff), commit.get_message())
+            }
+            None => (String::new(), String::new()),
         };
 
         write!(
             f,
-            "{0: <12} {1: <7} {2: <10}",
+            "{0: <11} {1: <3} {2: <10}",
             name,
             style(last_update).color256(241).italic(),
-            style(commit).color256(202),
+            style(message.truncate_to_boundary(30)).color256(202),
         )
     }
 }

--- a/src/commits/def.rs
+++ b/src/commits/def.rs
@@ -1,17 +1,16 @@
-use std::fmt::{Display, Formatter, Result};
-use truncrate::TruncateToBoundary;
-
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 #[derive(Debug, Clone, PartialEq)]
 pub struct Commit {
     hash: String,
-    timestamp: String,
+    timestamp: SystemTime,
     message: String,
 }
 
 impl Commit {
-    pub fn new(values: (String, String, String)) -> Commit {
+    pub fn new(values: (String, u64, String)) -> Commit {
         let hash = values.0.trim().to_string();
-        let timestamp = values.1;
+        let timestamp = UNIX_EPOCH + Duration::from_secs(values.1);
         let message = values.2;
         Commit {
             hash,
@@ -27,9 +26,14 @@ impl Commit {
     }
 }
 
-impl Display for Commit {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        let drained = &self.message.truncate_to_boundary(30);
-        write!(f, "{drained}")
+impl Commit {
+    pub fn get_timestamp(&self) -> SystemTime {
+        self.timestamp.clone()
+    }
+}
+
+impl Commit {
+    pub fn get_message(&self) -> String {
+        self.message.clone()
     }
 }

--- a/src/commits/utils.rs
+++ b/src/commits/utils.rs
@@ -10,14 +10,14 @@ pub fn get_commits(branch_path: PathBuf) -> Result<Vec<Commit>> {
         .lines()
         .filter(|line| line.contains("\tcommit"))
         .map(|line| {
-            let values = get_commit_values(line);
+            let values = get_commit_values(line).expect("Failed to parse String to u64");
             Commit::new(values)
         })
         .collect::<Vec<Commit>>();
     Ok(commits)
 }
 
-fn get_commit_values(line: &str) -> (String, String, String) {
+fn get_commit_values(line: &str) -> Result<(String, u64, String)> {
     let regex = Regex::new(
         r"(\w+)\s(?P<hash>\w+)\s(?P<author>.*>)\s(?P<timestamp>\d{10}).*\scommit\s?(\(\w*\))?:\s?(?P<name>.*)",
     ).expect("Failed to parse regex");
@@ -25,34 +25,39 @@ fn get_commit_values(line: &str) -> (String, String, String) {
     let hash = &caps["hash"];
     let timestamp = &caps["timestamp"];
     let name = &caps["name"];
-    (hash.to_string(), timestamp.to_string(), name.to_string())
+    Ok((
+        hash.to_string(),
+        timestamp.parse::<u64>()?,
+        name.to_string(),
+    ))
 }
-
 mod test {
     use super::*;
 
     #[test]
-    fn it_returns_commit_values() {
+    fn it_returns_commit_values() -> Result<()> {
         let line = "0dac748bd210848a29be86f56a2b7fe4e32ee669 55d376baa5ebe0d5fd377f008779778623985e82 vi17250 <v.aubinaud@protonmail.com> 1760637303 +0200 commit: feat: 🎸 commit msg";
         assert_eq!(
-            get_commit_values(line),
+            get_commit_values(line)?,
             (
                 String::from("55d376baa5ebe0d5fd377f008779778623985e82"),
-                String::from("1760637303"),
+                1760637303,
                 String::from("feat: 🎸 commit msg")
             )
         );
+        Ok(())
     }
     #[test]
-    fn it_returns_ammend_name() {
+    fn it_returns_ammend_name() -> Result<()> {
         let line = "0dac748bd210848a29be86f56a2b7fe4e32ee669 55d376baa5ebe0d5fd377f008779778623985e82 vi17250 <v.aubinaud@protonmail.com> 1760637303 +0200 commit (amend): feat: 🎸 commit msg";
         assert_eq!(
-            get_commit_values(line),
+            get_commit_values(line)?,
             (
                 String::from("55d376baa5ebe0d5fd377f008779778623985e82"),
-                String::from("1760637303"),
+                1760637303,
                 String::from("feat: 🎸 commit msg")
             )
         );
+        Ok(())
     }
 }

--- a/src/dialog/selection.rs
+++ b/src/dialog/selection.rs
@@ -104,7 +104,7 @@ mod test {
             SystemTime::now(),
             Some(Commit::new((
                 "hash1".to_string(),
-                "hash1".to_string(),
+                1234,
                 "hash1".to_string(),
             ))),
         );
@@ -115,7 +115,7 @@ mod test {
             SystemTime::now(),
             Some(Commit::new((
                 "hash2".to_string(),
-                "hash2".to_string(),
+                1234,
                 "hash2".to_string(),
             ))),
         );
@@ -130,7 +130,7 @@ mod test {
             SystemTime::now(),
             Some(Commit::new((
                 "hash3".to_string(),
-                "hash3".to_string(),
+                1234,
                 "hash3".to_string(),
             ))),
         );
@@ -141,7 +141,7 @@ mod test {
             SystemTime::now(),
             Some(Commit::new((
                 "hash4".to_string(),
-                "hash4".to_string(),
+                1234,
                 "hash4".to_string(),
             ))),
         );
@@ -160,7 +160,7 @@ mod test {
             SystemTime::now(),
             Some(Commit::new((
                 "hash5".to_string(),
-                "hash5".to_string(),
+                1234,
                 "hash5".to_string(),
             ))),
         );
@@ -171,7 +171,7 @@ mod test {
             SystemTime::now(),
             Some(Commit::new((
                 "hash6".to_string(),
-                "hash6".to_string(),
+                1234,
                 "hash6".to_string(),
             ))),
         );


### PR DESCRIPTION
instead of last branch update (which is not the goal here)