### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/vi17250/git-branch/compare/v0.1.0...v0.1.1) - 2025-12-10
+
+### Other
+
+- 💡 uses valinta as multi selector
+- 🤖 changelog uses the right repo
+- ✏️ remove github link
+- 🤖 remove useless crate `regex`
+- release v0.1.0
+
 ## [0.1.0](https://github.com/vi17250/git-branch/releases/tag/v0.1.0) - 2025-10-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "git-branch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-branch"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Victor Aubinaud"]
 description = "Use git-branch to manage local git branches interactively"


### PR DESCRIPTION



## 🤖 New release

* `git-branch`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.1.1](https://github.com/vi17250/git-branch/compare/v0.1.0...v0.1.1) - 2025-12-10

### Other

- 💡 uses valinta as multi selector
- 🤖 changelog uses the right repo
- ✏️ remove github link
- 🤖 remove useless crate `regex`
- release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).