### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/vi17250/git-branch/compare/v0.1.4...v0.1.5) - 2026-03-30
+
+### Fixed
+
+- 🐛 remove `Origin` feature
+
+### Other
+
+- *(deps)* 🤖 update to valinta 0.2.0
+- 💡 create a `file_system` module which find .git dir
+
 ## [0.1.4](https://github.com/vi17250/git-branch/compare/v0.1.3...v0.1.4) - 2026-03-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "git-branch"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "console",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-branch"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["Victor Aubinaud"]
 description = "Use git-branch to manage local git branches interactively"


### PR DESCRIPTION



## 🤖 New release

* `git-branch`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.1.5](https://github.com/vi17250/git-branch/compare/v0.1.4...v0.1.5) - 2026-03-30

### Fixed

- 🐛 remove `Origin` feature

### Other

- *(deps)* 🤖 update to valinta 0.2.0
- 💡 create a `file_system` module which find .git dir
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).